### PR TITLE
Added error for empty commit message

### DIFF
--- a/src/commit.rs
+++ b/src/commit.rs
@@ -29,6 +29,9 @@ pub fn commit_as_hook(commit_message: &str) -> Result<()> {
 
 pub fn commit(commit_message: &str) -> Result<()> {
     let output = git_exec(&["commit", "-m", commit_message])?;
+    if commit_message.chars().count() == 0 {
+        return Err(anyhow!("You must enter a commit message to commit changes."));
+    } 
     std::io::stdout().write_all(&output.stdout)?;
     std::io::stderr().write_all(&output.stderr)?;
     exit(


### PR DESCRIPTION
Small PR, just added a conditional to check for length of commit_message to ensure a comment was written for changes. Returns an error if nothing was written. 