### PR TITLE
docs: fix install from source git clone url

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ dnf install ./commit_0.6.0_x86_64.rpm
 Requires rust and cargo
 
 ```bash
-git https://github.com/alt-art/commit.git
+git clone https://github.com/alt-art/commit.git
 cd commit
 cargo build --release
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@ dnf install ./commit_0.6.0_x86_64.rpm
 Requires rust and cargo
 
 ```bash
-git clone https://github/alt-art/commit
+git https://github.com/alt-art/commit.git
 cd commit
 cargo build --release
 ```


### PR DESCRIPTION
Followint the `Install from source` instructions, when we try to clone the repo it returns the following error:

```
Cloning into 'commit'...
fatal: unable to access 'https://github/alt-art/commit/': Could not resolve host: github
```

It happens cause is missing the `.com` at github hostname.
This PR fix this.